### PR TITLE
Do nothing when we fail to get the size of the image

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,15 @@ function setImageSize(options) {
         if (dir && src.startsWith('/')) {
             src = path.join(dir, src)
         }
-        const dimensions = sizeOf(src)
-        node.properties.width = dimensions.width
-        node.properties.height = dimensions.height
+        
+        try {
+          const dimensions = sizeOf(src)
+          node.properties.width = dimensions.width
+          node.properties.height = dimensions.height
+        }
+        catch {
+          // do nothing 
+        }
       }
     }
   }


### PR DESCRIPTION
This stops the plugin from crashing when an image can't be sized. This is a simple catch all fix for #2 

