### PR TITLE
Fix TS typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
-import {ISize} from "image-size/dist/types/interface";
-import type {Root} from 'hast'
+import type { Plugin } from "unified";
+import type { Root } from "hast";
+
 interface Options {
   dir: string;
 }
-import type {Plugin} from 'unified'
 
-// Note: defining all nodes here, such as with `Root | Element | ...` seems
-// to trip TS up.
-declare const rehypeImgSize: Plugin<[Options] | [], Root, string>
-export default rehypeImgSize
-export type {Options}
+// If the plugin returns a transformer, then the `Output` type should be
+// the node type that the transformer yields
+declare const rehypeImgSize: Plugin<[Options?], Root, Root>;
+export default rehypeImgSize;
+export type { Options };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "rehype-img-size",
             "version": "1.0.1",
-            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "image-size": "^1.0.0",
@@ -15,6 +15,7 @@
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^21.0.1",
                 "@rollup/plugin-node-resolve": "^13.1.3",
+                "@types/hast": "^2.3.4",
                 "jest": "^27.3.1",
                 "rehype-stringify": "^9.0.2",
                 "remark-parse": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
+        "@types/hast": "^2.3.4",
         "jest": "^27.3.1",
         "rehype-stringify": "^9.0.2",
         "remark-parse": "^10.0.0",


### PR DESCRIPTION
Currently, the type of `rehypeImgSize` is `Plugin<[Options] | [], Root, string>`. While I'm using this plugin with `next-mdx-remote`, it gives the following error:

```
Type 'Plugin<[Options] | [], Root, string>' is not assignable to type 'Plugin<any[], any, any>'.
  The 'this' types of each signature are incompatible.
    Type 'Processor<void, any, void, void> | Processor<void, any, any, any> | Processor<any, any, void, void> | Processor<void, void, void, void>' is not assignable to type 'Processor<void, Root, Root, string>'.
      Type 'Processor<void, any, void, void>' is not assignable to type 'Processor<void, Root, Root, string>'.
        Type 'void' is not assignable to type 'Root'.ts(2322)
```

Since the plugin is returning a transformer, according to the documentation of `unified`, the `Output` type should be a node type, not string. I changed the `Output` type to `Root` and it is tested working with my setup.

I also added `@types/hast` as a dev dependency to add more robustness since it is missing in `package.json`.

Signed-off-by: imtsuki <me@qjx.app>