### PR TITLE
fix: replace Plugin type with Pluggable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,10 +3,10 @@ import type {Root} from 'hast'
 interface Options {
   dir: string;
 }
-import type {Plugin} from 'unified'
+import type {Pluggable} from 'unified'
 
 // Note: defining all nodes here, such as with `Root | Element | ...` seems
 // to trip TS up.
-declare const rehypeImgSize: Plugin<[Options] | [], Root, string>
+declare const rehypeImgSize: Pluggable<[Options] | [], Root, string>
 export default rehypeImgSize
 export type {Options}


### PR DESCRIPTION
Adding `rehypeImgSize` plugin into `mdx-bundler` causes the following type error
<img width="1238" alt="스크린샷 2022-12-14 오전 1 39 12" src="https://user-images.githubusercontent.com/70563791/207391643-0f6e8ffa-8aea-4d59-abb4-50d4600c5be8.png">

I guess it needs to be typed as `Pluggable`
